### PR TITLE
LPS-141244 Only enable for master

### DIFF
--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -545,6 +545,8 @@
     source.check.LanguageKeysCheck.portalLanguagePropertiesFileName=\
         modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
 
+    source.check.PoshiDependenciesFileLocationCheck.enabled=true
+
     source.check.PropertiesBuildIncludeDirsCheck.buildIncludeCategoryNames=\
         apps,\
         core,\


### PR DESCRIPTION
```
java.lang.Exception: Found 61 formatting issues:
1: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/dependencies/Blogs.portlet.lar' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/apps/ratings/ratings-test/src/testFunctional/Ratings.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
2: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/tests/dependencies/reports_admin_template_source_sample_class_name.jrxml' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/tests/CPReportsadmin.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
3: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/tests/dependencies/reports_admin_template_source_sample_class_name.jrxml' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testFunctional/tests/ReportsUsecase.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
4: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/dependencies/multi-task-process-workflow-definition.xml' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsList.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
5: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/dependencies/multi-task-process-workflow-definition.xml' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsList.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
6: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/dependencies/multi-task-process-workflow-definition.xml' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsListReassignTasks.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
7: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/dependencies/multi-task-process-workflow-definition.xml' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsListReassignTasks.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
8: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/dependencies/multi-task-process-workflow-definition.xml' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsWorkloadByStep.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
9: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/dependencies/multi-task-process-workflow-definition.xml' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsWorkloadByStep.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
10: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/groovy-script-master-slave.groovy' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/Clustering.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
11: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/groovy-script-portal-cache-get.groovy' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringCache.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
12: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/groovy-script-portal-cache-remove.groovy' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringCache.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
13: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/groovy-script-master-slave.groovy' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringMissingPlugins.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
14: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/groovy-script-portal-cache-get.groovy' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringMissingPlugins.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
15: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/groovy-script-portal-cache-remove.groovy' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/ClusteringMissingPlugins.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
16: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/jobTitle.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DataSourcesCSV.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
17: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/jobTitle.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DataSourcesDeletionCSV.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
18: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/jobTitle.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DeleteSegments.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
19: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/jobTitle.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IndividualsAttributeBreakdown.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
20: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/contacts_age.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
21: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/contacts_doNotCall.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
22: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/contacts_age.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsDistribution.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
23: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/contacts_age.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsOverviewAttributeBreakdown.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
24: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/dependencies/contacts_doNotCall.csv' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsOverviewAttributeBreakdown.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
25: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/dependencies/Blogs.portlet.lar' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsUsecase.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
26: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/dependencies/KBArticlesWithMarkdown.zip' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
27: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/dependencies/KBArticlesWithMarkdown.zip' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBDisplayWidget.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
28: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/dependencies/KBArticlesWithMetadata.zip' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBDisplayWidget.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
29: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/dependencies/KBArticlesWithMetadata.zip' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBUsecase.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
30: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/dependencies/adt_asset_publisher_rich_summary.ftl' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/ApplicationDisplayTemplates.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
31: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/dependencies/adt_asset_publisher_rich_summary.ftl' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/ApplicationDisplayTemplatesUseCase.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
32: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/dependencies/adt_categories_navigation_multi_column.ftl' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/ApplicationDisplayTemplatesUseCase.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
33: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/dependencies/adt_asset_publisher_rich_summary.ftl' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/ApplicationDisplayTemplatesWithStaging.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
34: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/dependencies/adt_categories_navigation_multi_column.ftl' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/applicationdisplaytemplate/ApplicationDisplayTemplatesWithStaging.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
35: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.css' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsAdmin.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
36: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsAdmin.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
37: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.js' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsAdmin.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
38: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_title.css' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsAdmin.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
39: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_title.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsAdmin.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
40: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/checkbox_configuration.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsConfiguration.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
41: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/checkbox_configuration.json' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsConfiguration.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
42: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/colorPalette_configuration.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsConfiguration.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
43: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/colorPalette_configuration.json' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsConfiguration.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
44: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/placeholder_configuration.json' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsConfiguration.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
45: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/text_configuration.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsConfiguration.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
46: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/checkbox_configuration.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
47: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/checkbox_configuration.json' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
48: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/colorPalette_configuration.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
49: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/colorPalette_configuration.json' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
50: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.css' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
51: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
52: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.js' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
53: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/placeholder_configuration.json' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
54: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/text_configuration.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
55: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.css' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsGlobal.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
56: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsGlobal.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
57: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.js' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsGlobal.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
58: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/checkbox_configuration.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsUI.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
59: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/checkbox_configuration.json' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsUI.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
60: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_title.css' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/contentpagetemplate/ContentPageTemplatesExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)
61: Test dependencies file '/Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_title.html' is referenced by multiple modules, move it to global dependencies directory: /Users/alan/liferay_code/master/liferay-portal/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/contentpagetemplate/ContentPageTemplatesExportImport.testcase (SourceCheck:PoshiDependenciesFileLocationCheck)

```