### PR TITLE
LPS-151508 Let two threads sync run Session#get. Otherwise, it still …

### DIFF
--- a/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/impl/test/ViewCountEntryLocalServiceTest.java
+++ b/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/impl/test/ViewCountEntryLocalServiceTest.java
@@ -173,22 +173,24 @@ public class ViewCountEntryLocalServiceTest {
 				if (Objects.equals("get", method.getName()) &&
 					(countDownLatch.getCount() > 0)) {
 
+					countDownLatch.countDown();
+
+					countDownLatch.await();
+
 					ViewCountEntry viewCountEntry =
 						(ViewCountEntry)method.invoke(session, args);
 
 					viewCountEntries.add(viewCountEntry);
 
-					countDownLatch.countDown();
-
-					countDownLatch.await();
-
 					Assert.assertNull(viewCountEntries.get(0));
 
-					if (_db.getDBType() == DBType.SQLSERVER) {
-						Assert.assertNotNull(viewCountEntries.get(1));
-					}
-					else {
-						Assert.assertNull(viewCountEntries.get(1));
+					if (viewCountEntries.size() == 2) {
+						if (_db.getDBType() == DBType.SQLSERVER) {
+							Assert.assertNotNull(viewCountEntries.get(1));
+						}
+						else {
+							Assert.assertNull(viewCountEntries.get(1));
+						}
 					}
 
 					return viewCountEntry;


### PR DESCRIPTION
…hangs on SQLSERVER. For example, if the separated thread "Inner View Count Incrementer'' firstly finishes Session#get and wait at countDownLatch.await(). At this time, its transaction is not completed, it will hold the lock. The current thread will wait(run (ViewCountEntry)method.invoke(session, args) to wait) until the "Inner View Count Incrementer" thread transaction finishes. So the test will hang