### PR TITLE
LPS-151902 Need to check if the logo exists in the current store, if …

### DIFF
--- a/modules/dxp/apps/portal/portal-properties-swapper/src/main/java/com/liferay/portal/properties/swapper/internal/DefaultGuestGroupLogoSwapper.java
+++ b/modules/dxp/apps/portal/portal-properties-swapper/src/main/java/com/liferay/portal/properties/swapper/internal/DefaultGuestGroupLogoSwapper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.properties.swapper.internal;
 
+import com.liferay.document.library.kernel.store.DLStore;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -47,7 +48,10 @@ public class DefaultGuestGroupLogoSwapper {
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			group.getGroupId(), false);
 
-		if (layoutSet.getLogoId() != 0) {
+		if ((layoutSet.getLogoId() != 0) &&
+			_dlStore.hasFile(
+				layoutSet.getCompanyId(), 0, layoutSet.getLogoId() + ".png")) {
+
 			return;
 		}
 
@@ -65,6 +69,9 @@ public class DefaultGuestGroupLogoSwapper {
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private DLStore _dlStore;
 
 	@Reference
 	private GroupLocalService _groupLocalService;


### PR DESCRIPTION
…not, we need to add it. For example, when the first startup portal with empty database and default FileSystemStore, and configure S3Store in ui. When restarting the portal and changing the current store (dl.store.impl=..S3Store in portal-ext), the logo won't be added to S3Store. When accessing a guest site, there is a resource request(http://localhost:8080/image/layout_set_logo?img_id=42201&t=1666950754616) to load the logo, the issue will happen.