### PR TITLE
remove Http.CookieSpec.STANDARD to reproduce

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/embedding/text/HuggingFaceInferenceAPITextEmbeddingProvider.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/ml/embedding/text/HuggingFaceInferenceAPITextEmbeddingProvider.java
@@ -92,7 +92,6 @@ public class HuggingFaceInferenceAPITextEmbeddingProvider
 			options.setBody(
 				jsonObject.toString(), ContentTypes.APPLICATION_JSON,
 				StringPool.UTF8);
-			options.setCookieSpec(Http.CookieSpec.STANDARD);
 			options.setLocation(
 				"https://api-inference.huggingface.co/models/" +
 					MapUtil.getString(attributes, "model"));


### PR DESCRIPTION
Hi @zhangyan0701 ,

Tina and I were trying to remove Http.CookieSpec.STANDARD, and see if we can reproduce https://issues.liferay.com/browse/LPS-167113.
Could you please verify for us?
FYI: https://issues.liferay.com/browse/LPS-167076, https://issues.liferay.com/browse/LPS-167377
Thanks for your help!
cc: @tinatian  